### PR TITLE
Do not pass args to hook.

### DIFF
--- a/chpwd/function.sh
+++ b/chpwd/function.sh
@@ -8,7 +8,7 @@ __zsh_like_cd()
     for __zsh_like_cd_hook in chpwd "${chpwd_functions[@]}"
     do
       if typeset -f "$__zsh_like_cd_hook" >/dev/null 2>&1
-      then "$__zsh_like_cd_hook" "$@" || break # finish on first failed hook
+      then "$__zsh_like_cd_hook" || break # finish on first failed hook
       fi
     done
     true


### PR DESCRIPTION
Zsh does not pass the args to the hook, so this version should not either.