### PR TITLE
fix support for zsh 5.4.1 onwards

### DIFF
--- a/chpwd/function.sh
+++ b/chpwd/function.sh
@@ -1,4 +1,4 @@
-__zsh_like_cd()
+function __zsh_like_cd()
 {
   \typeset __zsh_like_cd_hook
   if

--- a/chpwd/load.sh
+++ b/chpwd/load.sh
@@ -1,6 +1,6 @@
 [[ -n "${ZSH_VERSION:-}" ]] ||
 {
-  cd()    { __zsh_like_cd cd    "$@" ; }
-  popd()  { __zsh_like_cd popd  "$@" ; }
-  pushd() { __zsh_like_cd pushd "$@" ; }
+  function cd()    { __zsh_like_cd cd    "$@" ; }
+  function popd()  { __zsh_like_cd popd  "$@" ; }
+  function pushd() { __zsh_like_cd pushd "$@" ; }
 }


### PR DESCRIPTION
Since version 5.4.1, zsh won't allow the definition of functions using the `name()` syntax if `name` is already an alias.

The recommended way to define functions is to always use the `function` keyword, as aliases are not expanded afterwards.

See http://zsh.sourceforge.net/releases.html (5.3.1 to 5.4.1) and http://zsh.sourceforge.net/Doc/Release/Options.html#Scripts-and-Functions for more details.